### PR TITLE
RequestedRelease: make codename public

### DIFF
--- a/src/release.rs
+++ b/src/release.rs
@@ -35,7 +35,7 @@ pub struct RequestedRelease {
     mirror: Url,
     /// This can also be called "suite" in some places,
     /// e.g. "unstable" (suite) == "sid" (codename)
-    codename: String,
+    pub codename: String,
 
     pub arches: Vec<String>,
 }


### PR DESCRIPTION
This allows code which is iterating over `DownloadedList` objects returned by `System.listings()` to determine the relevant codename.