### PR TITLE
implement untrusted=yes support

### DIFF
--- a/src/release.rs
+++ b/src/release.rs
@@ -173,7 +173,7 @@ impl RequestedReleases {
                     &dest,
                 )],
             ) {
-                Ok(_) => gpg.verify_clearsigned(&dest, &verified),
+                Ok(_) => gpg.read_clearsigned(&dest, &verified, true),
                 Err(_) => {
                     let mut detatched_signature = dest.as_os_str().to_os_string();
                     detatched_signature.push(".gpg");

--- a/src/release.rs
+++ b/src/release.rs
@@ -185,14 +185,18 @@ impl RequestedReleases {
                         &[Download::from_to(release.dists()?.join("Release")?, &dest)],
                     )?;
 
-                    fetch(
-                        client,
-                        &[Download::from_to(
-                            release.dists()?.join("Release.gpg")?,
-                            &detatched_signature,
-                        )],
-                    )?;
-                    gpg.verify_detached(&dest, detatched_signature, verified)
+                    if !release.untrusted {
+                        fetch(
+                            client,
+                            &[Download::from_to(
+                                release.dists()?.join("Release.gpg")?,
+                                &detatched_signature,
+                            )],
+                        )?;
+                        gpg.verify_detached(&dest, detatched_signature, verified)
+                    } else {
+                        Ok(())
+                    }
                 }
             }
             .with_context(|| anyhow!("verifying {:?} at {:?}", release, dest))?;

--- a/src/release.rs
+++ b/src/release.rs
@@ -38,6 +38,7 @@ pub struct RequestedRelease {
     pub codename: String,
 
     pub arches: Vec<String>,
+    pub untrusted: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -139,6 +140,7 @@ impl RequestedReleases {
                 mirror: Url::parse(&entry.url)?,
                 codename: entry.suite_codename.to_string(),
                 arches: arches.to_vec(),
+                untrusted: entry.untrusted,
             }) {
                 hash_map::Entry::Vacant(vacancy) => {
                     vacancy.insert(vec![entry.clone()]);
@@ -173,7 +175,7 @@ impl RequestedReleases {
                     &dest,
                 )],
             ) {
-                Ok(_) => gpg.read_clearsigned(&dest, &verified, true),
+                Ok(_) => gpg.read_clearsigned(&dest, &verified, !release.untrusted),
                 Err(_) => {
                     let mut detatched_signature = dest.as_os_str().to_os_string();
                     detatched_signature.push(".gpg");

--- a/src/sources_list.rs
+++ b/src/sources_list.rs
@@ -18,7 +18,11 @@ pub struct Entry {
     pub untrusted: bool,
 }
 
-fn parse_opts(opts: &str) -> &str {
+struct ParsedOpts {
+    arch: String,
+}
+
+fn parse_opts(opts: &str) -> ParsedOpts {
     if opts.contains(" ") {
         panic!("only one option per line supported")
     }
@@ -34,7 +38,9 @@ fn parse_opts(opts: &str) -> &str {
             if parts[0] != "arch" {
                 panic!("unknown option: {}", parts[0])
             }
-            parts[1]
+            ParsedOpts {
+                arch: parts[1].to_string(),
+            }
         }
         _ => panic!("multiple = in option"),
     }
@@ -83,7 +89,7 @@ fn read_single_line(line: &str) -> Result<Vec<Entry>, Error> {
 
     let mut ret = Vec::with_capacity(srcs.len());
 
-    let arch = opts.map(|opts| parse_opts(opts));
+    let parsed_opts = opts.map(|opts| parse_opts(opts));
     for src in srcs {
         ret.push(Entry {
             src: *src,
@@ -94,7 +100,9 @@ fn read_single_line(line: &str) -> Result<Vec<Entry>, Error> {
             },
             suite_codename: suite.to_string(),
             components: components.iter().map(|x| x.to_string()).collect(),
-            arch: arch.map(|arch| arch.to_string()),
+            arch: parsed_opts
+                .as_ref()
+                .map(|parsed_opts| parsed_opts.arch.clone()),
             untrusted: false,
         });
     }

--- a/src/sources_list.rs
+++ b/src/sources_list.rs
@@ -24,10 +24,10 @@ struct ParsedOpts {
     untrusted: Option<bool>,
 }
 
-fn parse_opts(opts: Option<&str>) -> ParsedOpts {
-    if let Some(opts) = opts {
+fn parse_opts(opts: Option<&str>) -> Result<ParsedOpts, Error> {
+    Ok(if let Some(opts) = opts {
         if opts.contains(" ") {
-            panic!("only one option per line supported")
+            bail!("only one option per line supported")
         }
         let parts: Vec<_> = opts
             .strip_prefix("[")
@@ -46,13 +46,13 @@ fn parse_opts(opts: Option<&str>) -> ParsedOpts {
                     arch: None,
                     untrusted: Some(parts[1] == "yes"),
                 },
-                other => panic!("unknown option: {}", other),
+                other => bail!("unknown option: {}", other),
             },
-            _ => panic!("multiple = in option"),
+            _ => bail!("multiple = in option"),
         }
     } else {
         ParsedOpts::default()
-    }
+    })
 }
 
 fn read_single_line(line: &str) -> Result<Vec<Entry>, Error> {
@@ -98,7 +98,7 @@ fn read_single_line(line: &str) -> Result<Vec<Entry>, Error> {
 
     let mut ret = Vec::with_capacity(srcs.len());
 
-    let parsed_opts = parse_opts(opts);
+    let parsed_opts = parse_opts(opts)?;
     for src in srcs {
         ret.push(Entry {
             src: *src,

--- a/src/sources_list.rs
+++ b/src/sources_list.rs
@@ -15,6 +15,7 @@ pub struct Entry {
     pub suite_codename: String,
     pub components: Vec<String>,
     pub arch: Option<String>,
+    pub untrusted: bool,
 }
 
 fn read_single_line(line: &str) -> Result<Vec<Entry>, Error> {
@@ -71,6 +72,7 @@ fn read_single_line(line: &str) -> Result<Vec<Entry>, Error> {
             suite_codename: suite.to_string(),
             components: components.iter().map(|x| x.to_string()).collect(),
             arch: arch.map(|arch| arch.to_string()),
+            untrusted: false,
         });
     }
 
@@ -113,6 +115,7 @@ mod tests {
                     url: "http://foo/".to_string(),
                     suite_codename: "bar".to_string(),
                     components: vec!["baz".to_string(), "quux".to_string()],
+                    untrusted: false,
                 },
                 Entry {
                     src: true,
@@ -120,6 +123,7 @@ mod tests {
                     url: "http://foo/".to_string(),
                     suite_codename: "bar".to_string(),
                     components: vec!["baz".to_string(), "quux".to_string()],
+                    untrusted: false,
                 },
             ],
             read(io::Cursor::new(

--- a/src/sources_list.rs
+++ b/src/sources_list.rs
@@ -25,7 +25,8 @@ struct ParsedOpts {
 }
 
 fn parse_opts(opts: Option<&str>) -> Result<ParsedOpts, Error> {
-    Ok(if let Some(opts) = opts {
+    let mut ret = ParsedOpts::default();
+    if let Some(opts) = opts {
         if opts.contains(" ") {
             bail!("only one option per line supported")
         }
@@ -38,21 +39,14 @@ fn parse_opts(opts: Option<&str>) -> Result<ParsedOpts, Error> {
             .collect();
         match parts.len() {
             2 => match parts[0] {
-                "arch" => ParsedOpts {
-                    arch: Some(parts[1].to_string()),
-                    untrusted: None,
-                },
-                "untrusted" => ParsedOpts {
-                    arch: None,
-                    untrusted: Some(parts[1] == "yes"),
-                },
+                "arch" => ret.arch = Some(parts[1].to_string()),
+                "untrusted" => ret.untrusted = Some(parts[1] == "yes"),
                 other => bail!("unknown option: {}", other),
             },
             _ => bail!("multiple = in option"),
         }
-    } else {
-        ParsedOpts::default()
-    })
+    };
+    Ok(ret)
 }
 
 fn read_single_line(line: &str) -> Result<Vec<Entry>, Error> {


### PR DESCRIPTION
This comprises three parts:
* refactoring `verify_clearsigned` to `read_clearsigned` to allow skipping of signature verification
* refactoring of `release` to store and handle `untrusted`
* adding support for option parsing to `sources_list`

This last part also fixes `[arch=...]` parsing (which previously was storing more than just the arch value).